### PR TITLE
Migrate to modern Python Logger API

### DIFF
--- a/wenet/utils/train_utils.py
+++ b/wenet/utils/train_utils.py
@@ -136,8 +136,8 @@ def add_lora_args(parser):
     parser.add_argument("--only_optimize_lora",
                         default=False,
                         type=bool,
-                        help="freeze all other paramters and only optimize \
-                        LoRA-related prameters.")
+                        help="freeze all other parameters and only optimize \
+                        LoRA-related parameters.")
     parser.add_argument(
         '--lora_modules',
         default="encoder.encoders",
@@ -213,7 +213,7 @@ def add_deepspeed_args(parser):
                         default='model_only',
                         choices=['model_only', 'model+optimizer'],
                         help='save model/optimizer states')
-    # DeepSpeed automaticly add '--deepspeed' and '--deepspeed_config' to parser
+    # DeepSpeed automatically add '--deepspeed' and '--deepspeed_config' to parser
     try:
         parser = deepspeed.add_config_arguments(parser)
     except Exception as e:
@@ -298,7 +298,7 @@ def check_modify_and_save_config(args, configs, symbol_table):
         #               == gradient_clipping (in ds_config.json)`
         #   The reason for such consistence checking lies in that deepspeed's native
         #   dataloader uses PyTorch's torch.utils.data.DistributedSampler which does
-        #   not support IterableDataset, IterableDataset is extremly useful in large
+        #   not support IterableDataset, IterableDataset is extremely useful in large
         #   scale training because it lets you stream the data without having to
         #   download the complete dataset.
         #       ref: https://github.com/microsoft/DeepSpeed/issues/1371
@@ -364,7 +364,7 @@ def check_modify_and_save_config(args, configs, symbol_table):
             fout.write(data)
 
     if configs["model_conf"].get("apply_non_blank_embedding", False):
-        logging.warn('Had better load a well trained model'
+        logging.warning('Had better load a well trained model'
                      'if apply_non_blank_embedding is true !!!')
 
     return configs


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
It also fixes a few typos along the way.